### PR TITLE
Fix typo in `ibm_is_volume` table docs

### DIFF
--- a/docs/tables/ibm_is_volume.md
+++ b/docs/tables/ibm_is_volume.md
@@ -1,7 +1,7 @@
 # Table: ibm_is_volume
 
-Block Storage for VPC provides hypervisor-mounted, high-performance data storage for your virtual server instances that you can provision within an IBM Cloud™ Virtual Private Cloud (VPC). The VPC infrastructure provides rapid scaling across zones and extra performance and security.
-
+Block Storage for VPC provides hypervisor-mounted, high-performance data storage for your virtual server instances that you can provision within an IBM Cloud Virtual Private Cloud (VPC). The VPC infrastructure provides rapid scaling across zones and extra performance and security.
+Block Storage for VPC offers block-level volumes that are attached to an instance as a boot volume when the instance is created or attached as secondary data volumes.
 
 ## Examples
 
@@ -33,7 +33,36 @@ where
   name = 'steampipe01';
 ```
 
-### Instance count in each availability zone
+### List of volumes with size more than 100GB
+
+```sql
+select
+  name,
+  id,
+  crn,
+  capacity
+from
+  ibm_is_volume
+where
+  capacity > 100;
+```
+
+### List volumes not encrypted using user-managed key
+
+```sql
+select
+  name,
+  id,
+  crn,
+  encryption,
+  encryption_key
+from
+  ibm_is_volume
+where
+  encryption <> 'user_managed';
+```
+
+### Volume count in each availability zone
 
 ```sql
 select


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
