### PR TITLE
Add floating IP details in table ibm_is_instance Closes #45

### DIFF
--- a/docs/tables/ibm_is_instance.md
+++ b/docs/tables/ibm_is_instance.md
@@ -61,9 +61,9 @@ from
 ```sql
 select 
   name,
-  fip -> 'target' ->> 'id' as "Network Interface Id",
-  fip ->> 'address' as "Floating Ip",
-  fip ->> 'created_at' as "Create Time" 
+  fip -> 'target' ->> 'id' as network_interface_id,
+  fip ->> 'address' as floating_ip,
+  fip ->> 'created_at' as create_time 
 from 
   ibm_is_instance,
   jsonb_array_elements(floating_ips) as fip;

--- a/docs/tables/ibm_is_instance.md
+++ b/docs/tables/ibm_is_instance.md
@@ -55,3 +55,16 @@ from
   ibm_is_instance,
   jsonb_array_elements(disks) as d;
 ```
+
+### Get floating ips associated to the instances
+
+```sql
+select 
+  title,
+  fip -> 'target' ->> 'id' as "Network Interface Id",
+  fip ->> 'address' as "Floating Ip",
+  fip ->> 'created_at' as "Create Time" 
+from 
+  ibm_is_instance,
+  jsonb_array_elements(floating_ips) as fip;
+```

--- a/docs/tables/ibm_is_instance.md
+++ b/docs/tables/ibm_is_instance.md
@@ -60,7 +60,7 @@ from
 
 ```sql
 select 
-  title,
+  name,
   fip -> 'target' ->> 'id' as "Network Interface Id",
   fip ->> 'address' as "Floating Ip",
   fip ->> 'created_at' as "Create Time" 

--- a/ibm/table_ibm_is_instance.go
+++ b/ibm/table_ibm_is_instance.go
@@ -204,7 +204,7 @@ func getInstanceNetworkInterfaceFloatingIps(ctx context.Context, d *plugin.Query
 		return nil, err
 	}
 
-	networkInterfaces := *&vpc.NetworkInterfaces
+	networkInterfaces := vpc.NetworkInterfaces
 	networkInterfaceFloatingIp := []vpcv1.FloatingIP{}
 
 	for _, networkInterface := range networkInterfaces {


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
select 
  title,
  fip -> 'target' ->> 'id' as "Network Interface Id",
  fip ->> 'address' as "Floating Ip",
  fip ->> 'created_at' as "Create Time" 
from 
  ibm_is_instance,
  jsonb_array_elements(floating_ips) as fip;
+-------------+-------------------------------------------+----------------+--------------------------+
| title       | Network Interface Id                      | Floating Ip    | Create Time              |
+-------------+-------------------------------------------+----------------+--------------------------+
| steampipe01 | 0727-5cd2f29a-ea9f-499e-9476-717310c38218 | 150.239.166.18 | 2022-04-19T12:31:44.000Z |
+-------------+-------------------------------------------+----------------+--------------------------+
```
</details>
