### PR TITLE
Add Address Prefixes details in table ibm_is_vpc Closes #43

### DIFF
--- a/docs/tables/ibm_is_vpc.md
+++ b/docs/tables/ibm_is_vpc.md
@@ -37,10 +37,10 @@ where
 ```sql
 select
   name,
-  addressp ->> 'cidr' as "IP Range",
-  addressp -> 'zone' ->> 'name' as "Region",
-  addressp ->> 'created_at' as "Create Time",
-  addressp ->> 'is_default' as "Is default"
+  addressp ->> 'cidr' as "cidr",
+  addressp -> 'zone' ->> 'name' as "zone",
+  addressp ->> 'created_at' as "created_at",
+  addressp ->> 'is_default' as "is_default"
 from
   ibm_is_vpc,
   jsonb_array_elements(address_prefixes) addressp;

--- a/docs/tables/ibm_is_vpc.md
+++ b/docs/tables/ibm_is_vpc.md
@@ -31,3 +31,17 @@ from
 where
   classic_access;
 ```
+
+### List address prefix details for VPCs
+
+```sql
+select
+  name,
+  addressp ->> 'cidr' as "IP Range",
+  addressp -> 'zone' ->> 'name' as "Region",
+  addressp ->> 'created_at' as "Create Time",
+  addressp ->> 'is_default' as "Is default"
+from
+  ibm_is_vpc,
+  jsonb_array_elements(address_prefixes) addressp;
+```

--- a/ibm/table_ibm_cos_bucket.go
+++ b/ibm/table_ibm_cos_bucket.go
@@ -23,12 +23,15 @@ func tableCosBucket(ctx context.Context) *plugin.Table {
 		Columns: []*plugin.Column{
 			{Name: "name", Type: proto.ColumnType_STRING, Description: "Name of the bucket."},
 			{Name: "creation_date", Type: proto.ColumnType_TIMESTAMP, Description: "The date when the bucket was created."},
+			{Name: "owner_id", Type: proto.ColumnType_STRING, Description: "The ID of this bucket owner.", Transform: transform.FromField("Owner.ID")},
 			{Name: "sse_kp_customer_root_key_crn", Type: proto.ColumnType_STRING, Description: "The root key used by Key Protect to encrypt this bucket. This value must be the full CRN of the root key.", Hydrate: headBucket, Transform: transform.FromField("IBMSSEKPCrkId")},
 			{Name: "sse_kp_enabled", Type: proto.ColumnType_BOOL, Description: "Specifies whether the Bucket has Key Protect enabled.", Hydrate: headBucket, Transform: transform.FromField("IBMSSEKPEnabled"), Default: false},
 			{Name: "versioning_enabled", Type: proto.ColumnType_BOOL, Description: "The versioning state of a bucket.", Hydrate: getBucketVersioning, Transform: transform.FromField("Status").Transform(handleNilString).Transform(transform.ToBool)},
 			{Name: "versioning_mfa_delete", Type: proto.ColumnType_BOOL, Description: "The MFA Delete status of the versioning state.", Hydrate: getBucketVersioning, Transform: transform.FromField("MFADelete").Transform(handleNilString).Transform(transform.ToBool)},
 			{Name: "acl", Type: proto.ColumnType_JSON, Description: "The access control list (ACL) of a bucket.", Hydrate: getBucketACL, Transform: transform.FromValue()},
+			{Name: "cors_rules", Type: proto.ColumnType_JSON, Description: "The Cross-Origin Resource Sharing (CORS) configuration of a bucket.", Hydrate: getBucketCORSConfiguration, Transform: transform.FromValue()},
 			{Name: "lifecycle_rules", Type: proto.ColumnType_JSON, Description: "The lifecycle configuration information of the bucket.", Hydrate: getBucketLifecycle, Transform: transform.FromField("Rules")},
+			{Name: "logging_enabled", Type: proto.ColumnType_JSON, Description: "The logging information of the bucket.", Hydrate: getBucketLogging},
 			{Name: "public_access_block_configuration", Type: proto.ColumnType_JSON, Description: "The public access block configuration information of the bucket.", Hydrate: getBucketPublicAccessBlockConfiguration, Transform: transform.FromValue()},
 			{Name: "retention", Type: proto.ColumnType_JSON, Description: "The retention configuration information of the bucket.", Hydrate: getBucketRetention, Transform: transform.FromValue()},
 			{Name: "website", Type: proto.ColumnType_JSON, Description: "The lifecycle configuration information of the bucket.", Hydrate: getBucketWebsite, Transform: transform.FromValue()},
@@ -303,6 +306,72 @@ func getBucketPublicAccessBlockConfiguration(ctx context.Context, d *plugin.Quer
 		if strings.Contains(err.Error(), "NoSuchPublicAccessBlockConfiguration") {
 			return nil, nil
 		}
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func getBucketCORSConfiguration(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	plugin.Logger(ctx).Trace("getBucketCORSConfiguration")
+	serviceType := plugin.GetMatrixItem(ctx)["service_type"].(string)
+
+	// Invalid service type
+	if serviceType != "cloud-object-storage" {
+		return nil, nil
+	}
+	bucket := h.Item.(*s3.BucketExtended)
+
+	location := strings.TrimSuffix(*bucket.LocationConstraint, "-smart")
+
+	// Create Session
+	conn, err := cosService(ctx, d, location)
+	if err != nil {
+		return nil, err
+	}
+
+	params := &s3.GetBucketCorsInput{
+		Bucket: bucket.Name,
+	}
+
+	result, err := conn.GetBucketCors(params)
+	if err != nil {
+		if strings.Contains(err.Error(), "NoSuchCORSConfiguration") {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	return result.CORSRules, nil
+}
+
+func getBucketLogging(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	plugin.Logger(ctx).Trace("getBucketLogging")
+	serviceType := plugin.GetMatrixItem(ctx)["service_type"].(string)
+
+	// Invalid service type
+	if serviceType != "cloud-object-storage" {
+		return nil, nil
+	}
+	bucket := h.Item.(*s3.BucketExtended)
+
+	location := strings.TrimSuffix(*bucket.LocationConstraint, "-smart")
+
+	// Create Session
+	conn, err := cosService(ctx, d, location)
+	if err != nil {
+		return nil, err
+	}
+
+	params := &s3.GetBucketLoggingInput{
+		Bucket: bucket.Name,
+	}
+
+	result, err := conn.GetBucketLogging(params)
+	if err != nil {
+		// if strings.Contains(err.Error(), "NoSuchCORSConfiguration") {
+		// 	return nil, nil
+		// }
 		return nil, err
 	}
 

--- a/ibm/table_ibm_is_vpc.go
+++ b/ibm/table_ibm_is_vpc.go
@@ -38,6 +38,7 @@ func tableIbmIsVpc(ctx context.Context) *plugin.Table {
 			{Name: "id", Type: proto.ColumnType_STRING, Description: "The unique identifier for this VPC."},
 			{Name: "name", Type: proto.ColumnType_STRING, Description: "The unique user-defined name for this VPC."},
 			// Other columns
+			{Name: "address_prefixes", Type: proto.ColumnType_JSON, Description: "Array of all address pool prefixes for this VPC.", Hydrate: getVpcAddressPrefixes, Transform: transform.FromValue()},
 			{Name: "classic_access", Type: proto.ColumnType_BOOL, Description: "Indicates whether this VPC is connected to Classic Infrastructure."},
 			{Name: "crn", Type: proto.ColumnType_STRING, Transform: transform.FromField("CRN"), Description: "The CRN for this VPC."},
 			{Name: "created_at", Type: proto.ColumnType_TIMESTAMP, Transform: transform.FromField("CreatedAt").Transform(ensureTimestamp), Description: "The date and time that the VPC was created."},
@@ -210,4 +211,27 @@ func getTags(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (i
 	}
 
 	return tags, nil
+}
+
+func getVpcAddressPrefixes(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	region := plugin.GetMatrixItem(ctx)["region"].(string)
+	vpc := h.Item.(vpcv1.VPC)
+
+	// Create service connection
+	conn, err := vpcService(ctx, d, region)
+	if err != nil {
+		plugin.Logger(ctx).Error("ibm_is_vpc.getVpcAddressPrefixes", "connection_error", err)
+		return nil, err
+	}
+
+	opts := &vpcv1.ListVPCAddressPrefixesOptions{
+		VPCID: vpc.ID,
+	}
+
+	result, resp, err := conn.ListVPCAddressPrefixesWithContext(ctx, opts)
+	if err != nil {
+		plugin.Logger(ctx).Error("ibm_is_vpc.getVpcAddressPrefixes", "query_error", err, "resp", resp)
+		return nil, err
+	}
+	return result.AddressPrefixes, nil
 }


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  name,
  addressp ->> 'cidr' as "IP Range",
  addressp -> 'zone' ->> 'name' as "Region",
  addressp ->> 'created_at' as "Create Time",
  addressp ->> 'is_default' as "Is default"
from
  ibm_is_vpc,
  jsonb_array_elements(address_prefixes) addressp;
+--------+-----------------+------------+--------------------------+------------+
| name   | IP Range        | Region     | Create Time              | Is default |
+--------+-----------------+------------+--------------------------+------------+
| test2  | 10.240.0.0/18   | us-south-1 | 2021-03-27T21:16:09.000Z | true       |
| test2  | 10.240.64.0/18  | us-south-2 | 2021-03-27T21:16:09.000Z | true       |
| test2  | 10.240.128.0/18 | us-south-3 | 2021-03-27T21:16:09.000Z | true       |
| test   | 10.240.0.0/18   | us-south-1 | 2021-03-27T20:34:48.000Z | true       |
| test   | 10.240.64.0/18  | us-south-2 | 2021-03-27T20:34:48.000Z | true       |
| test   | 10.240.128.0/18 | us-south-3 | 2021-03-27T20:34:48.000Z | true       |
| eutest | 10.243.128.0/18 | eu-de-3    | 2021-03-27T21:16:37.000Z | true       |
| eutest | 10.243.0.0/18   | eu-de-1    | 2021-03-27T21:16:37.000Z | true       |
| eutest | 10.243.64.0/18  | eu-de-2    | 2021-03-27T21:16:37.000Z | true       |
+--------+-----------------+------------+--------------------------+------------+
```
</details>
